### PR TITLE
Implemented Scriptable Objects for Food-Types and Integrated Cost Management System

### DIFF
--- a/Assets/Data.meta
+++ b/Assets/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd3c4128ea612594a8a36bb245d0e4b9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Free.meta
+++ b/Assets/Data/Free.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 374a6fd3909cfd94a802ec8f8a89d30f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Free/Food 1.asset
+++ b/Assets/Data/Free/Food 1.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58141c3bb10f1d440813787e56bd1c1a, type: 3}
+  m_Name: Food 1
+  m_EditorClassIdentifier: 
+  foodCost: 5
+  damage: 1
+  staminaTime: 8
+  destructionTime: 14

--- a/Assets/Data/Free/Food 1.asset.meta
+++ b/Assets/Data/Free/Food 1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc592f2c99ac3464292fa527674ea0c0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Free/Food 2.asset
+++ b/Assets/Data/Free/Food 2.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58141c3bb10f1d440813787e56bd1c1a, type: 3}
+  m_Name: Food 2
+  m_EditorClassIdentifier: 
+  foodCost: 6
+  damage: 2
+  staminaTime: 14
+  destructionTime: 24

--- a/Assets/Data/Free/Food 2.asset.meta
+++ b/Assets/Data/Free/Food 2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e11fc2cd685b6c449948e764863c4c7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Free/Food 3.asset
+++ b/Assets/Data/Free/Food 3.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58141c3bb10f1d440813787e56bd1c1a, type: 3}
+  m_Name: Food 3
+  m_EditorClassIdentifier: 
+  foodCost: 7
+  damage: 3
+  staminaTime: 22
+  destructionTime: 32

--- a/Assets/Data/Free/Food 3.asset.meta
+++ b/Assets/Data/Free/Food 3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a3ef8bbf6f68e940bda77dfb509d5ca
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Paid.meta
+++ b/Assets/Data/Paid.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2991db3af5b551648b8aa05579a375b4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Paid/Food 4.asset
+++ b/Assets/Data/Paid/Food 4.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58141c3bb10f1d440813787e56bd1c1a, type: 3}
+  m_Name: Food 4
+  m_EditorClassIdentifier: 
+  foodCost: 8
+  damage: 5
+  staminaTime: 28
+  destructionTime: 40

--- a/Assets/Data/Paid/Food 4.asset.meta
+++ b/Assets/Data/Paid/Food 4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dcd5b3ec58665f046b100514ed4631fa
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Paid/Food 5.asset
+++ b/Assets/Data/Paid/Food 5.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58141c3bb10f1d440813787e56bd1c1a, type: 3}
+  m_Name: Food 5
+  m_EditorClassIdentifier: 
+  foodCost: 10
+  damage: 7
+  staminaTime: 40
+  destructionTime: 55

--- a/Assets/Data/Paid/Food 5.asset.meta
+++ b/Assets/Data/Paid/Food 5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4ce1d25ca99ce014bb62a7a51e9014ea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1244,6 +1244,7 @@ MonoBehaviour:
   upgradeFood: {fileID: 1082591539}
   currencyText: {fileID: 617309895}
   moneyAmount: 0
+  gmInstance: {fileID: 1690839831}
 --- !u!1 &1333480598
 GameObject:
   m_ObjectHideFlags: 0
@@ -1369,7 +1370,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   followerPrefab: {fileID: 330837507758328382, guid: 9a696a01e46e38943abac0710abd878f, type: 3}
   targetPrefab: {fileID: 4858843760271760619, guid: b72df548180d24e4c89f265511e19511, type: 3}
-  _spawnedObject: {fileID: 0}
+  foodTypes:
+  - {fileID: 11400000, guid: 0eaa17e7bad000e458b53ea0601cd2f6, type: 2}
+  - {fileID: 11400000, guid: eb9cf03ac2d73454e982d298b7733afb, type: 2}
+  - {fileID: 11400000, guid: 4c3cd8035f60c414da2e4238413fc891, type: 2}
+  - {fileID: 11400000, guid: 620a89b2e4aa3cc4585d56a2febf0daa, type: 2}
+  - {fileID: 11400000, guid: 02d456610936a89468c32e666025106f, type: 2}
 --- !u!4 &1690839833
 Transform:
   m_ObjectHideFlags: 0
@@ -1675,9 +1681,9 @@ SceneRoots:
   - {fileID: 736617469}
   - {fileID: 883318421}
   - {fileID: 872643956}
-  - {fileID: 2088931380}
   - {fileID: 1690839833}
   - {fileID: 1157081291}
+  - {fileID: 2088931380}
   - {fileID: 2122178206}
   - {fileID: 1481859857}
   - {fileID: 762708542}

--- a/Assets/Scripts/Game Economy/FoodProperties.cs
+++ b/Assets/Scripts/Game Economy/FoodProperties.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+[CreateAssetMenu(fileName = "FoodProperties", menuName = "Game Economy/Food Properties")]
+public class FoodProperties : ScriptableObject
+{
+    public int foodCost;
+    public int damage;
+    public float staminaTime;
+    public float destructionTime;
+}

--- a/Assets/Scripts/Game Economy/FoodProperties.cs.meta
+++ b/Assets/Scripts/Game Economy/FoodProperties.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58141c3bb10f1d440813787e56bd1c1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game Managers Scripts/GameEvents.cs
+++ b/Assets/Scripts/Game Managers Scripts/GameEvents.cs
@@ -5,12 +5,13 @@ using UnityEngine;
 
 public class GameEvents : MonoBehaviour
 {
-    // Singleton
+    // Reference to the instance of the GameEvents class
     public static GameEvents eventsChannelInstance;
 
     // Events
     public event Action<int> onSpawnObject;
-    public event Action<float> onUpdateCoins;
+    public event Action<int> onUpdateCoins;
+    public event Action onUpgradeFood;
 
     private void Awake()
     {
@@ -31,9 +32,13 @@ public class GameEvents : MonoBehaviour
         onSpawnObject?.Invoke(obj: objectType);
     }
 
-    public void UpdateInGameSceneMoney(float coins)
+    public void UpdateInGameSceneMoney(int coins)
     {
         onUpdateCoins?.Invoke(coins);
     }
 
+    public void UpgradeFood()
+    {
+        onUpgradeFood?.Invoke();
+    }
 }

--- a/Assets/Scripts/Game Managers Scripts/UIManager.cs
+++ b/Assets/Scripts/Game Managers Scripts/UIManager.cs
@@ -7,10 +7,10 @@ public class UIManager : MonoBehaviour
     public Button upgradeFood;
     public TMPro.TextMeshProUGUI currencyText;
 
-    [SerializeField] float moneyAmount = 0;
+    [SerializeField] int moneyAmount = 0;
 
 
-    void GetMoneyValue(float coinsValue)
+    void GetMoneyValue(int coinsValue)
     {
         moneyAmount = coinsValue;
         currencyText.text = moneyAmount.ToString() + "$";
@@ -23,7 +23,7 @@ public class UIManager : MonoBehaviour
         GameEvents.eventsChannelInstance.onUpdateCoins += GetMoneyValue;
 
         spawnObject.onClick.AddListener(() => GameEvents.eventsChannelInstance?.SpawnObjects(1));
-        //upgradeFood.onClick.AddListener(() => GameEvents.eventsChannelInstance?.SpawnObjects(2));
+        upgradeFood.onClick.AddListener(() => GameEvents.eventsChannelInstance?.UpgradeFood());
     }
 
 
@@ -34,4 +34,6 @@ public class UIManager : MonoBehaviour
         spawnObject.onClick.RemoveAllListeners();
         //upgradeFood.onClick.RemoveAllListeners();
     }
+
+
 }

--- a/Assets/Scripts/Target Scripts/Target.cs
+++ b/Assets/Scripts/Target Scripts/Target.cs
@@ -6,6 +6,8 @@ public class Target : MonoBehaviour
 {
     public int objectID;
 
+    public FoodProperties foodConfig;
+
     private void Update()
     {
         transform.position += Vector3.down * Time.deltaTime;

--- a/Assets/Target.prefab
+++ b/Assets/Target.prefab
@@ -119,3 +119,4 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   objectID: 0
+  foodConfig: {fileID: 0}


### PR DESCRIPTION
This reverts commit 66944358f1cbc1d9d8a3cf4202f0e0d65c3b65b1.

- **Day 16:**
**16.1.**
Developed the Scriptable-Object script to manage various food-related data within the game.
**16.2.**
Created 5 distinct Scriptable-Objects with predefined values for later use, dividing them between 3 for the Free version and 2 for the Paid version of the game.

- **Day 17:**
**17.1.**
In the Game-Manager script, introduced a list of type “Food-Properties” to store all Scriptable-Objects, representing different food types.
**17.2.**
Each newly initiated TargetObject is now assigned a current Food-Type from this list.
**17.3.**
Implemented a cost management system where the In-Scene-Money is decreased by the assigned Food-Type's cost whenever a TargetObject is initiated.
**17.4.**
Added a restriction to ensure that players can only initiate a new TargetObject if their In-Scene-Money is greater than the cost of the assigned Food-Type.
**17.5.**
Enhanced the UI by adding a new button in the UIManager script that allows players to upgrade the Food-Type assigned to the next TargetObject, with this interaction managed via the Game-Events system.