### PR TITLE
Enhanced FollowerObject Hunger System with Food-Type-Based Timers

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1244,7 +1244,6 @@ MonoBehaviour:
   upgradeFood: {fileID: 1082591539}
   currencyText: {fileID: 617309895}
   moneyAmount: 0
-  gmInstance: {fileID: 1690839831}
 --- !u!1 &1333480598
 GameObject:
   m_ObjectHideFlags: 0
@@ -1370,12 +1369,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   followerPrefab: {fileID: 330837507758328382, guid: 9a696a01e46e38943abac0710abd878f, type: 3}
   targetPrefab: {fileID: 4858843760271760619, guid: b72df548180d24e4c89f265511e19511, type: 3}
+  inSceneMoney: 0
   foodTypes:
-  - {fileID: 11400000, guid: 0eaa17e7bad000e458b53ea0601cd2f6, type: 2}
-  - {fileID: 11400000, guid: eb9cf03ac2d73454e982d298b7733afb, type: 2}
-  - {fileID: 11400000, guid: 4c3cd8035f60c414da2e4238413fc891, type: 2}
-  - {fileID: 11400000, guid: 620a89b2e4aa3cc4585d56a2febf0daa, type: 2}
-  - {fileID: 11400000, guid: 02d456610936a89468c32e666025106f, type: 2}
+  - {fileID: 11400000, guid: fc592f2c99ac3464292fa527674ea0c0, type: 2}
+  - {fileID: 11400000, guid: 0e11fc2cd685b6c449948e764863c4c7, type: 2}
+  - {fileID: 11400000, guid: 3a3ef8bbf6f68e940bda77dfb509d5ca, type: 2}
+  - {fileID: 11400000, guid: dcd5b3ec58665f046b100514ed4631fa, type: 2}
+  - {fileID: 11400000, guid: 4ce1d25ca99ce014bb62a7a51e9014ea, type: 2}
 --- !u!4 &1690839833
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Follower Controling Scripts/FollowerController.cs
+++ b/Assets/Scripts/Follower Controling Scripts/FollowerController.cs
@@ -18,9 +18,8 @@ public class FollowerController : MonoBehaviour
     #region Hunger Situation Variables
 
     [SerializeField] float timeBeforeGettingHungry = 0f;
-    float hungerStartingTime = 5f;
-    //float hungerEndingTime = 8f;
-    float timeBeforeDying = 15f;
+    [SerializeField] float hungerStartingTime = 5f;
+    [SerializeField] float timeBeforeDying = 15f;
     #endregion
 
     private void Start()
@@ -48,6 +47,11 @@ public class FollowerController : MonoBehaviour
         else if (lastNearestObject != null && (transform.position - lastNearestObject.transform.position).sqrMagnitude <= inRangeThreshold && IsHungry())
         {
             timeBeforeGettingHungry = 0f;
+
+            FoodProperties hungerConfigs = lastNearestObject.GetComponent<Target>().foodConfig;
+            hungerStartingTime = hungerConfigs.staminaTime;
+            timeBeforeDying = hungerConfigs.destructionTime;
+
             RemoveTargetObjectFromList(lastNearestObject);
             Destroy(lastNearestObject);
         }

--- a/Assets/Scripts/Game Managers Scripts/GameManager.cs
+++ b/Assets/Scripts/Game Managers Scripts/GameManager.cs
@@ -154,14 +154,14 @@ public class GameManager : MonoBehaviour
 
     void UpgradeFood()
     {
-        if (inSceneMoney >= foodUpgradeCost && currentFoodIndex <= foodTypes.Length - 1)
+        if (inSceneMoney >= foodUpgradeCost && currentFoodIndex < foodTypes.Length - 1)
         {
             // Deduct the cost of the food upgrade from the in-scene money
             currentFoodIndex = (currentFoodIndex + 1) % foodTypes.Length;
             inSceneMoney -= foodUpgradeCost;
             GameEvents.eventsChannelInstance.UpdateInGameSceneMoney(inSceneMoney);
 
-            Debug.Log("Current food index = " + currentFoodIndex);
+            Debug.Log("Current food index = " + currentFoodIndex + ", And food type is: " + foodTypes[currentFoodIndex].name);
         }
     }
 


### PR DESCRIPTION
- **Day 16:**
**16.1.**
Developed the Scriptable-Object script to manage various food-related data within the game.
**16.2.**
Created 5 distinct Scriptable-Objects with predefined values for later use, dividing them between 3 for the Free version and 2 for the Paid version of the game.

- **Day 17:**
**17.1.**
In the Game-Manager script, introduced a list of type “Food-Properties” to store all Scriptable-Objects, representing different food types.
**17.2.**
Each newly initiated TargetObject is now assigned a current Food-Type from this list.
**17.3.**
Implemented a cost management system where the In-Scene-Money is decreased by the assigned Food-Type's cost whenever a TargetObject is initiated.
**17.4.**
Added a restriction to ensure that players can only initiate a new TargetObject if their In-Scene-Money is greater than the cost of the assigned Food-Type.
**17.5.**
Enhanced the UI by adding a new button in the UIManager script that allows players to upgrade the Food-Type assigned to the next TargetObject, with this interaction managed via the Game-Events system.
### **_(New Feature)_**
- **17.6.**
Modified the FollowerObject's Hunger system so that when it reaches (or "eats") a TargetObject, it inherits the "Stamina" value as the Time-Before-Getting-Hungry again and the "Destruction Time" value as the Time-Before-Dying. These timers are now based on the specific Food-Type assigned to the consumed TargetObject, allowing for dynamic and varied gameplay.